### PR TITLE
Базовое чтение методов

### DIFF
--- a/src/main/java/org/silverbulleters/bsl/platform/context/BSLPlatformContext.java
+++ b/src/main/java/org/silverbulleters/bsl/platform/context/BSLPlatformContext.java
@@ -26,10 +26,13 @@ import org.silverbulleters.bsl.platform.context.internal.PlatformContextStorage;
 import org.silverbulleters.bsl.platform.context.internal.util.ContextInitializer;
 import org.silverbulleters.bsl.platform.context.platform.ContextType;
 import org.silverbulleters.bsl.platform.context.platform.Event;
+import org.silverbulleters.bsl.platform.context.platform.Method;
 import org.silverbulleters.bsl.platform.context.platform.PlatformEdition;
+import org.silverbulleters.bsl.platform.context.types.PlatformTypeIdentifier;
+import org.silverbulleters.bsl.platform.context.types.PlatformTypeReference;
 
 import java.util.List;
-import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * API над контекстом платформы
@@ -51,8 +54,37 @@ public class BSLPlatformContext {
    * @return набор событий типов
    */
   @NotNull
-  public Set<Event> getEventsByPlatform(@NotNull PlatformEdition edition) {
+  public List<Event> getEventsByPlatform(@NotNull PlatformEdition edition) {
     return storage.getEventsByPlatform(edition);
+  }
+
+  /**
+   * @param edition - версия платформы
+   * @return список методов глобального контекста, доступных в переданной версии платформы
+   */
+  @NotNull
+  public List<Method> getGlobalMethodsByPlatform(@NotNull PlatformEdition edition) {
+    var globalContextReference = new PlatformTypeReference(PlatformTypeIdentifier.GLOBAL_CONTEXT.value());
+
+    return storage.getTypesByPlatform(edition).stream()
+        .filter(type -> type.getReference().equals(globalContextReference))
+        .flatMap(type -> type.getMethods().stream())
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * @param edition - - версия платформы
+   * @param typeIdentifier - идентификатор типа, методы которого необходимо получить
+   * @return список методов, доступных для переданного типа
+   */
+  @NotNull
+  public List<Method> getTypeMethodsByPlatform(@NotNull PlatformEdition edition, PlatformTypeIdentifier typeIdentifier) {
+    var typeReference = new PlatformTypeReference(typeIdentifier.value());
+
+    return storage.getTypesByPlatform(edition).stream()
+        .filter(type -> type.getReference().equals(typeReference))
+        .flatMap(type -> type.getMethods().stream())
+        .collect(Collectors.toList());
   }
 
   /**
@@ -62,7 +94,7 @@ public class BSLPlatformContext {
    * @return набор типов
    */
   @NotNull
-  public Set<ContextType> getTypesByPlatform(@NotNull PlatformEdition edition) {
+  public List<ContextType> getTypesByPlatform(@NotNull PlatformEdition edition) {
     return storage.getTypesByPlatform(edition);
   }
 

--- a/src/main/java/org/silverbulleters/bsl/platform/context/internal/BaseMethod.java
+++ b/src/main/java/org/silverbulleters/bsl/platform/context/internal/BaseMethod.java
@@ -25,6 +25,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 import org.silverbulleters.bsl.platform.context.types.ContextItem;
 import org.silverbulleters.bsl.platform.context.types.Resource;
 
@@ -34,6 +35,7 @@ import org.silverbulleters.bsl.platform.context.types.Resource;
 @Getter
 @Setter(AccessLevel.PACKAGE)
 @AllArgsConstructor
+@ToString
 public abstract class BaseMethod implements ContextItem {
   /**
    * Имя метода на двух языках

--- a/src/main/java/org/silverbulleters/bsl/platform/context/internal/PlatformContext.java
+++ b/src/main/java/org/silverbulleters/bsl/platform/context/internal/PlatformContext.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.NotNull;
 import org.silverbulleters.bsl.platform.context.platform.ContextType;
 import org.silverbulleters.bsl.platform.context.platform.Event;
 
-import java.util.Set;
+import java.util.List;
 
 /**
  * Контекст по конкретной версии платформы
@@ -39,10 +39,10 @@ public class PlatformContext {
    * Набор типов
    */
   @NotNull
-  Set<ContextType> types;
+  List<ContextType> types;
   /**
    * Набор событий
    */
   @NotNull
-  Set<Event> events;
+  List<Event> events;
 }

--- a/src/main/java/org/silverbulleters/bsl/platform/context/internal/PlatformContextStorage.java
+++ b/src/main/java/org/silverbulleters/bsl/platform/context/internal/PlatformContextStorage.java
@@ -31,9 +31,9 @@ import org.silverbulleters.bsl.platform.context.types.PlatformTypeReference;
 
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Внутреннее API над контекстами платформы
@@ -60,10 +60,10 @@ public class PlatformContextStorage {
    * @param platformEdition - версия платформы
    * @return
    */
-  public Set<Event> getEventsByPlatform(@NotNull PlatformEdition platformEdition) {
+  public List<Event> getEventsByPlatform(@NotNull PlatformEdition platformEdition) {
     var platformContext = Optional.ofNullable(contextByEditions.get(platformEdition));
     if (platformContext.isEmpty()) {
-      return Collections.emptySet();
+      return Collections.emptyList();
     }
     return platformContext.get().getEvents();
   }
@@ -74,10 +74,10 @@ public class PlatformContextStorage {
    * @param platformEdition - версия платформы
    * @return
    */
-  public Set<ContextType> getTypesByPlatform(@NotNull PlatformEdition platformEdition) {
+  public List<ContextType> getTypesByPlatform(@NotNull PlatformEdition platformEdition) {
     var platformContext = Optional.ofNullable(contextByEditions.get(platformEdition));
     if (platformContext.isEmpty()) {
-      return Collections.emptySet();
+      return Collections.emptyList();
     }
     return platformContext.get().getTypes();
   }

--- a/src/main/java/org/silverbulleters/bsl/platform/context/internal/data/DataFromCollector.java
+++ b/src/main/java/org/silverbulleters/bsl/platform/context/internal/data/DataFromCollector.java
@@ -22,6 +22,7 @@
 package org.silverbulleters.bsl.platform.context.internal.data;
 
 import lombok.Data;
+import org.silverbulleters.bsl.platform.context.platform.Method;
 
 import java.util.List;
 
@@ -60,6 +61,11 @@ public class DataFromCollector {
      * Имя типа на английском
      */
     private String nameRu;
+
+    /**
+     * Методы типа платформы
+     */
+    private List<Method> methods;
   }
 
   /**
@@ -79,6 +85,28 @@ public class DataFromCollector {
      * Список типов платформы, у которых есть текущее событие
      */
     private List<String> types;
+  }
+
+  /**
+   * Представление метода
+   */
+  @Data
+  public static class Method {
+
+    /**
+     * Имя метода на английском
+     */
+    private String name;
+
+    /**
+     * Имя метода на русском
+     */
+    private String nameRu;
+
+    /**
+     * Признак, является ли метод функцией
+     */
+    private Boolean isFunction;
   }
 
 }

--- a/src/main/java/org/silverbulleters/bsl/platform/context/platform/ContextType.java
+++ b/src/main/java/org/silverbulleters/bsl/platform/context/platform/ContextType.java
@@ -26,6 +26,8 @@ import lombok.Value;
 import org.silverbulleters.bsl.platform.context.types.PlatformTypeReference;
 import org.silverbulleters.bsl.platform.context.types.Resource;
 
+import java.util.List;
+
 /**
  * Определение типа платформы
  */
@@ -35,6 +37,6 @@ public class ContextType {
   Resource name;
   PlatformTypeReference reference;
   boolean isPrimitive;
+  List<Method> methods;
   // свойства
-  // методы
 }

--- a/src/main/java/org/silverbulleters/bsl/platform/context/platform/Method.java
+++ b/src/main/java/org/silverbulleters/bsl/platform/context/platform/Method.java
@@ -21,16 +21,30 @@
  */
 package org.silverbulleters.bsl.platform.context.platform;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.Value;
 import org.silverbulleters.bsl.platform.context.internal.BaseMethod;
+import org.silverbulleters.bsl.platform.context.internal.data.DataFromCollector;
 import org.silverbulleters.bsl.platform.context.types.Resource;
 
 /**
  * Определение метода типа
  */
+@Value
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 public class Method extends BaseMethod {
 
-  public Method(Resource name) {
-    super(name);
+  boolean isFunction;
+
+  public static Method createMethodFromData(DataFromCollector.Method methodFromData) {
+    var resource = new Resource(methodFromData.getNameRu(), methodFromData.getName());
+    return new Method(resource, methodFromData.getIsFunction());
   }
 
+  public Method(Resource name, boolean isFunction) {
+    super(name);
+    this.isFunction = isFunction;
+  }
 }

--- a/src/test/java/org/silverbulleters/bsl/platform/context/BSLPlatformContextTest.java
+++ b/src/test/java/org/silverbulleters/bsl/platform/context/BSLPlatformContextTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.silverbulleters.bsl.platform.context.internal.PlatformContextStorage;
 import org.silverbulleters.bsl.platform.context.internal.util.ReadDataCollector;
 import org.silverbulleters.bsl.platform.context.platform.PlatformEdition;
+import org.silverbulleters.bsl.platform.context.types.PlatformTypeIdentifier;
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,6 +39,34 @@ class BSLPlatformContextTest {
     checkBSLContext(PlatformEdition.VERSION_8_3_10);
     checkBSLContext(PlatformEdition.VERSION_8_2_19);
     checkBSLContext(List.of(PlatformEdition.VERSION_8_2_19, PlatformEdition.VERSION_8_3_10));
+  }
+
+  @Test
+  void testReadingGlobalMethodsFromFile() {
+    var context = new BSLPlatformContext(List.of(PlatformEdition.VERSION_8_3_10));
+    var globalMethods = context.getGlobalMethodsByPlatform(PlatformEdition.VERSION_8_3_10);
+    assertThat(globalMethods).isNotEmpty();
+  }
+
+  @Test
+  void testReadingMethodDataFromFile() {
+    var context = new BSLPlatformContext(List.of(PlatformEdition.VERSION_8_3_10));
+    var globalMethods = context.getGlobalMethodsByPlatform(PlatformEdition.VERSION_8_3_10);
+    var strLenMethod = globalMethods.stream()
+        .filter(method -> method.getName().getNameEn().equals("StrLen"))
+        .findFirst().orElseThrow(IllegalArgumentException::new);
+
+    assertThat(strLenMethod.getName().getNameEn()).isEqualTo("StrLen");
+    assertThat(strLenMethod.getName().getNameRu()).isEqualTo("СтрДлина");
+    assertThat(strLenMethod.isFunction()).isTrue();
+  }
+
+  @Test
+  void testReadingObjectMethodsFromFile() {
+    var context = new BSLPlatformContext(List.of(PlatformEdition.VERSION_8_3_10));
+    var objectMethods = context.getTypeMethodsByPlatform(PlatformEdition.VERSION_8_3_10,
+        PlatformTypeIdentifier.DOCUMENT_OBJECT);
+    assertThat(objectMethods).isNotEmpty();
   }
 
   @Test


### PR DESCRIPTION
Добавлено базовое чтение методов типов платформы (глобальный контекст + методы объектов (e.g. ДокументОбъект)

close #4 